### PR TITLE
Add Vanity URL

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,4 +17,4 @@ linters:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/fogo-sh/almanac
+    local-prefixes: pkg.fogo.sh/almanac

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fogo-sh/almanac/pkg/content"
+	"pkg.fogo.sh/almanac/pkg/content"
 )
 
 var outputCmd = &cobra.Command{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/fogo-sh/almanac/pkg/server"
+	"pkg.fogo.sh/almanac/pkg/server"
 )
 
 var serveCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fogo-sh/almanac
+module pkg.fogo.sh/almanac
 
 go 1.21.0
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/fogo-sh/almanac/cmd"
+import "pkg.fogo.sh/almanac/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/content/parsing.go
+++ b/pkg/content/parsing.go
@@ -13,7 +13,7 @@ import (
 	"go.abhg.dev/goldmark/frontmatter"
 	"go.abhg.dev/goldmark/wikilink"
 
-	"github.com/fogo-sh/almanac/pkg/utils"
+	"pkg.fogo.sh/almanac/pkg/utils"
 )
 
 type PageMeta struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,8 +17,8 @@ import (
 	slogecho "github.com/samber/slog-echo"
 	"golang.org/x/oauth2"
 
-	"github.com/fogo-sh/almanac/pkg/content"
-	"github.com/fogo-sh/almanac/pkg/static"
+	"pkg.fogo.sh/almanac/pkg/content"
+	"pkg.fogo.sh/almanac/pkg/static"
 )
 
 type Config struct {


### PR DESCRIPTION
Migrate from `github.com/fogo-sh/almanac` to `pkg.fogo.sh/almanac`

I've deployed a [Dieppe](https://github.com/nint8835/dieppe) instance to the Nitfrastructure for Fogo.sh. Currently it's just used for this but could be used for more Go modules in the future, or for Docker images if I ever end up actually adding that functionality.

Config: https://github.com/fogo-sh/pkg.fogo.sh