### PR TITLE
Discord mention support

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -23,16 +23,16 @@ var outputCmd = &cobra.Command{
 			slog.Warn("Failed to create Discord user resolver, Discord user mentions will not be resolved", "error", err)
 		}
 
-		renderer := content.Renderer{DiscordUserResolver: resolver}
+		parser := content.Parser{DiscordUserResolver: resolver}
 
-		pages, err := renderer.DiscoverPages(contentDir)
+		pages, err := parser.DiscoverPages(contentDir)
 		checkError(err, "failed to discover pages")
 
 		outputDir := must(cmd.Flags().GetString("output-dir"))
 
 		slog.Info(fmt.Sprintf("discovered %d pages, outputting to %s", len(pages), outputDir))
 
-		err = renderer.OutputAllPagesToDisk(pages, outputDir)
+		err = parser.OutputAllPagesToDisk(pages, outputDir)
 		checkError(err, "failed to output pages")
 
 		slog.Info("done!")

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -5,8 +5,10 @@ import (
 	"log/slog"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"pkg.fogo.sh/almanac/pkg/content"
+	"pkg.fogo.sh/almanac/pkg/content/extensions"
 )
 
 var outputCmd = &cobra.Command{
@@ -16,14 +18,21 @@ var outputCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		contentDir := must(cmd.Flags().GetString("content-dir"))
 
-		pages, err := content.DiscoverPages(contentDir)
+		resolver, err := extensions.NewDiscordUserResolver(viper.GetString("discord.token"))
+		if err != nil {
+			slog.Warn("Failed to create Discord user resolver, Discord user mentions will not be resolved", "error", err)
+		}
+
+		renderer := content.Renderer{DiscordUserResolver: resolver}
+
+		pages, err := renderer.DiscoverPages(contentDir)
 		checkError(err, "failed to discover pages")
 
 		outputDir := must(cmd.Flags().GetString("output-dir"))
 
 		slog.Info(fmt.Sprintf("discovered %d pages, outputting to %s", len(pages), outputDir))
 
-		err = content.OutputAllPagesToDisk(pages, outputDir)
+		err = renderer.OutputAllPagesToDisk(pages, outputDir)
 		checkError(err, "failed to output pages")
 
 		slog.Info("done!")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ var serveCmd = &cobra.Command{
 			DiscordCallbackUrl:  viper.GetString("discord.callback_url"),
 			DiscordGuildId:      viper.GetString("discord.guild_id"),
 			SessionSecret:       viper.GetString("discord.session_secret"),
+			DiscordToken:        viper.GetString("discord.token"),
 		})
 		err := serverInstance.Start()
 		checkError(err, "failed to start server")

--- a/example-content/Riley.md
+++ b/example-content/Riley.md
@@ -1,3 +1,5 @@
 +++
 categories = ["Contributors"]
 +++
+
+Discord user: <@106162668032802816>

--- a/pkg/content/discover.go
+++ b/pkg/content/discover.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-func CreateSpecialPages(pages map[string]*Page) error {
+func (r *Renderer) CreateSpecialPages(pages map[string]*Page) error {
 	specialPages := make([]string, 0)
 
-	pagesByCategory := PagesByCategory(pages)
-	allCategories := AllCategories(pages)
+	pagesByCategory := r.PagesByCategory(pages)
+	allCategories := r.AllCategories(pages)
 
 	for _, category := range allCategories {
 		keysOfPagesInCategory := make([]string, 0, len(pagesByCategory[category]))
@@ -58,7 +58,7 @@ func CreateSpecialPages(pages map[string]*Page) error {
 	return nil
 }
 
-func DiscoverPages(path string) (map[string]*Page, error) {
+func (r *Renderer) DiscoverPages(path string) (map[string]*Page, error) {
 	paths, error := filepath.Glob(filepath.Join(path, "*.md"))
 
 	if error != nil {
@@ -68,7 +68,7 @@ func DiscoverPages(path string) (map[string]*Page, error) {
 	pages := make(map[string]*Page)
 
 	for _, path := range paths {
-		page, error := ParsePageFile(path)
+		page, error := r.ParsePageFile(path)
 		if error != nil {
 			return nil, fmt.Errorf("failed to parse page: %w", error)
 		}
@@ -76,17 +76,17 @@ func DiscoverPages(path string) (map[string]*Page, error) {
 		pages[page.Title] = &page
 	}
 
-	err := CreateSpecialPages(pages)
+	err := r.CreateSpecialPages(pages)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create special pages: %w", err)
 	}
 
-	PopulateBacklinks(pages)
+	r.PopulateBacklinks(pages)
 
 	return pages, nil
 }
 
-func PopulateBacklinks(pages map[string]*Page) {
+func (r *Renderer) PopulateBacklinks(pages map[string]*Page) {
 	for _, page := range pages {
 		for _, link := range page.LinksTo {
 			if _, ok := pages[link]; ok {
@@ -113,7 +113,7 @@ func PopulateBacklinks(pages map[string]*Page) {
 	}
 }
 
-func AllPageTitles(pages map[string]*Page) []string {
+func (r *Renderer) AllPageTitles(pages map[string]*Page) []string {
 	allPageTitles := make([]string, 0, len(pages))
 	for key := range pages {
 		allPageTitles = append(allPageTitles, key)
@@ -126,7 +126,7 @@ func AllPageTitles(pages map[string]*Page) []string {
 	return allPageTitles
 }
 
-func PagesByCategory(pages map[string]*Page) map[string][]*Page {
+func (r *Renderer) PagesByCategory(pages map[string]*Page) map[string][]*Page {
 	pagesByCategory := make(map[string][]*Page)
 
 	for _, page := range pages {
@@ -138,7 +138,7 @@ func PagesByCategory(pages map[string]*Page) map[string][]*Page {
 	return pagesByCategory
 }
 
-func AllCategories(pages map[string]*Page) []string {
+func (r *Renderer) AllCategories(pages map[string]*Page) []string {
 	categories := map[string]struct{}{}
 	for _, page := range pages {
 		for _, category := range page.Meta.Categories {
@@ -154,7 +154,7 @@ func AllCategories(pages map[string]*Page) []string {
 	return keys
 }
 
-func FindRootPage(pages map[string]*Page) (*Page, error) {
+func (r *Renderer) FindRootPage(pages map[string]*Page) (*Page, error) {
 	var rootPage *Page
 
 	for _, page := range pages {

--- a/pkg/content/discover.go
+++ b/pkg/content/discover.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-func (r *Renderer) CreateSpecialPages(pages map[string]*Page) error {
+func (p *Parser) CreateSpecialPages(pages map[string]*Page) error {
 	specialPages := make([]string, 0)
 
-	pagesByCategory := r.PagesByCategory(pages)
-	allCategories := r.AllCategories(pages)
+	pagesByCategory := p.PagesByCategory(pages)
+	allCategories := p.AllCategories(pages)
 
 	for _, category := range allCategories {
 		keysOfPagesInCategory := make([]string, 0, len(pagesByCategory[category]))
@@ -58,7 +58,7 @@ func (r *Renderer) CreateSpecialPages(pages map[string]*Page) error {
 	return nil
 }
 
-func (r *Renderer) DiscoverPages(path string) (map[string]*Page, error) {
+func (p *Parser) DiscoverPages(path string) (map[string]*Page, error) {
 	paths, error := filepath.Glob(filepath.Join(path, "*.md"))
 
 	if error != nil {
@@ -68,7 +68,7 @@ func (r *Renderer) DiscoverPages(path string) (map[string]*Page, error) {
 	pages := make(map[string]*Page)
 
 	for _, path := range paths {
-		page, error := r.ParsePageFile(path)
+		page, error := p.ParsePageFile(path)
 		if error != nil {
 			return nil, fmt.Errorf("failed to parse page: %w", error)
 		}
@@ -76,17 +76,17 @@ func (r *Renderer) DiscoverPages(path string) (map[string]*Page, error) {
 		pages[page.Title] = &page
 	}
 
-	err := r.CreateSpecialPages(pages)
+	err := p.CreateSpecialPages(pages)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create special pages: %w", err)
 	}
 
-	r.PopulateBacklinks(pages)
+	p.PopulateBacklinks(pages)
 
 	return pages, nil
 }
 
-func (r *Renderer) PopulateBacklinks(pages map[string]*Page) {
+func (p *Parser) PopulateBacklinks(pages map[string]*Page) {
 	for _, page := range pages {
 		for _, link := range page.LinksTo {
 			if _, ok := pages[link]; ok {
@@ -113,7 +113,7 @@ func (r *Renderer) PopulateBacklinks(pages map[string]*Page) {
 	}
 }
 
-func (r *Renderer) AllPageTitles(pages map[string]*Page) []string {
+func (p *Parser) AllPageTitles(pages map[string]*Page) []string {
 	allPageTitles := make([]string, 0, len(pages))
 	for key := range pages {
 		allPageTitles = append(allPageTitles, key)
@@ -126,7 +126,7 @@ func (r *Renderer) AllPageTitles(pages map[string]*Page) []string {
 	return allPageTitles
 }
 
-func (r *Renderer) PagesByCategory(pages map[string]*Page) map[string][]*Page {
+func (p *Parser) PagesByCategory(pages map[string]*Page) map[string][]*Page {
 	pagesByCategory := make(map[string][]*Page)
 
 	for _, page := range pages {
@@ -138,7 +138,7 @@ func (r *Renderer) PagesByCategory(pages map[string]*Page) map[string][]*Page {
 	return pagesByCategory
 }
 
-func (r *Renderer) AllCategories(pages map[string]*Page) []string {
+func (p *Parser) AllCategories(pages map[string]*Page) []string {
 	categories := map[string]struct{}{}
 	for _, page := range pages {
 		for _, category := range page.Meta.Categories {
@@ -154,7 +154,7 @@ func (r *Renderer) AllCategories(pages map[string]*Page) []string {
 	return keys
 }
 
-func (r *Renderer) FindRootPage(pages map[string]*Page) (*Page, error) {
+func (p *Parser) FindRootPage(pages map[string]*Page) (*Page, error) {
 	var rootPage *Page
 
 	for _, page := range pages {

--- a/pkg/content/extensions/discord_mention.go
+++ b/pkg/content/extensions/discord_mention.go
@@ -1,0 +1,99 @@
+package extensions
+
+import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+var DiscordMentionKind = ast.NewNodeKind("DiscordMention")
+
+type DiscordMentionNode struct {
+	ast.BaseInline
+
+	ID string
+}
+
+func (m *DiscordMentionNode) Dump(source []byte, level int) {
+	ast.DumpHelper(
+		m,
+		source,
+		level,
+		map[string]string{
+			"ID": m.ID,
+		},
+		nil)
+}
+
+func (m *DiscordMentionNode) Kind() ast.NodeKind {
+	return DiscordMentionKind
+}
+
+var _ ast.Node = (*DiscordMentionNode)(nil)
+
+type discordMentionParser struct{}
+
+func (d discordMentionParser) Trigger() []byte {
+	return []byte("<")
+}
+
+func (d discordMentionParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	line, _ := block.PeekLine()
+
+	lineHead := 0
+	userId := ""
+	inMention := false
+
+	for ; lineHead < len(line); lineHead++ {
+		char := line[lineHead]
+
+		if char == '@' {
+			inMention = true
+		} else if inMention && char == '>' {
+			break
+		} else if inMention {
+			userId += string(char)
+		}
+	}
+
+	block.Advance(lineHead + 1)
+
+	return &DiscordMentionNode{
+		ID: userId,
+	}
+}
+
+var _ parser.InlineParser = (*discordMentionParser)(nil)
+
+type discordMentionRenderer struct{}
+
+func (r *discordMentionRenderer) render(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	//node := n.(*DiscordMentionNode)
+	w.WriteString("Pretend this is a Discord mention")
+
+	return ast.WalkContinue, nil
+}
+
+func (r *discordMentionRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(DiscordMentionKind, r.render)
+}
+
+var _ renderer.NodeRenderer = (*discordMentionRenderer)(nil)
+
+type DiscordMention struct{}
+
+func (d *DiscordMention) Extend(m goldmark.Markdown) {
+	m.Renderer().AddOptions(renderer.WithNodeRenderers(util.Prioritized(&discordMentionRenderer{}, 500)))
+	m.Parser().AddOptions(parser.WithInlineParsers(util.Prioritized(discordMentionParser{}, 500)))
+}
+
+func NewDiscordMention() goldmark.Extender {
+	return &DiscordMention{}
+}

--- a/pkg/content/output.go
+++ b/pkg/content/output.go
@@ -9,7 +9,7 @@ import (
 	cp "github.com/otiai10/copy"
 )
 
-func (r *Renderer) OutputAllPagesToDisk(pages map[string]*Page, outputDir string) error {
+func (p *Parser) OutputAllPagesToDisk(pages map[string]*Page, outputDir string) error {
 	os.RemoveAll(outputDir)
 
 	err := os.MkdirAll(outputDir, 0755)
@@ -17,7 +17,7 @@ func (r *Renderer) OutputAllPagesToDisk(pages map[string]*Page, outputDir string
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	allPageTitles := r.AllPageTitles(pages)
+	allPageTitles := p.AllPageTitles(pages)
 
 	for key, page := range pages {
 		outputPath := outputDir + key + ".html"

--- a/pkg/content/output.go
+++ b/pkg/content/output.go
@@ -9,7 +9,7 @@ import (
 	cp "github.com/otiai10/copy"
 )
 
-func OutputAllPagesToDisk(pages map[string]*Page, outputDir string) error {
+func (r *Renderer) OutputAllPagesToDisk(pages map[string]*Page, outputDir string) error {
 	os.RemoveAll(outputDir)
 
 	err := os.MkdirAll(outputDir, 0755)
@@ -17,7 +17,7 @@ func OutputAllPagesToDisk(pages map[string]*Page, outputDir string) error {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	allPageTitles := AllPageTitles(pages)
+	allPageTitles := r.AllPageTitles(pages)
 
 	for key, page := range pages {
 		outputPath := outputDir + key + ".html"

--- a/pkg/content/parsing.go
+++ b/pkg/content/parsing.go
@@ -13,6 +13,7 @@ import (
 	"go.abhg.dev/goldmark/frontmatter"
 	"go.abhg.dev/goldmark/wikilink"
 
+	"pkg.fogo.sh/almanac/pkg/content/extensions"
 	"pkg.fogo.sh/almanac/pkg/utils"
 )
 
@@ -63,6 +64,7 @@ func ParsePageFile(path string) (Page, error) {
 				},
 			},
 		},
+		extensions.NewDiscordMention(),
 	))
 
 	ctx := parser.NewContext()

--- a/pkg/content/parsing.go
+++ b/pkg/content/parsing.go
@@ -34,7 +34,11 @@ type Page struct {
 	ParsedContent []byte
 }
 
-func ParsePageFile(path string) (Page, error) {
+type Renderer struct {
+	DiscordUserResolver *extensions.DiscordUserResolver
+}
+
+func (r *Renderer) ParsePageFile(path string) (Page, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return Page{}, fmt.Errorf("failed to open file: %w", err)
@@ -64,7 +68,7 @@ func ParsePageFile(path string) (Page, error) {
 				},
 			},
 		},
-		extensions.NewDiscordMention(&extensions.DiscordUserResolver{Cache: map[string]string{"106162668032802816": "nint8835"}}),
+		extensions.NewDiscordMention(r.DiscordUserResolver),
 	))
 
 	ctx := parser.NewContext()

--- a/pkg/content/parsing.go
+++ b/pkg/content/parsing.go
@@ -34,11 +34,11 @@ type Page struct {
 	ParsedContent []byte
 }
 
-type Renderer struct {
+type Parser struct {
 	DiscordUserResolver *extensions.DiscordUserResolver
 }
 
-func (r *Renderer) ParsePageFile(path string) (Page, error) {
+func (p *Parser) ParsePageFile(path string) (Page, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return Page{}, fmt.Errorf("failed to open file: %w", err)
@@ -68,7 +68,7 @@ func (r *Renderer) ParsePageFile(path string) (Page, error) {
 				},
 			},
 		},
-		extensions.NewDiscordMention(r.DiscordUserResolver),
+		extensions.NewDiscordMention(p.DiscordUserResolver),
 	))
 
 	ctx := parser.NewContext()

--- a/pkg/content/parsing.go
+++ b/pkg/content/parsing.go
@@ -64,7 +64,7 @@ func ParsePageFile(path string) (Page, error) {
 				},
 			},
 		},
-		extensions.NewDiscordMention(),
+		extensions.NewDiscordMention(&extensions.DiscordUserResolver{Cache: map[string]string{"106162668032802816": "nint8835"}}),
 	))
 
 	ctx := parser.NewContext()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,7 +40,7 @@ type Server struct {
 	echoInst *echo.Echo
 	config   Config
 	oauth    *oauth2.Config
-	renderer *content.Renderer
+	parser   *content.Parser
 }
 
 func (s *Server) Start() error {
@@ -148,7 +148,7 @@ func (s *Server) servePage(c echo.Context) error {
 
 	pageKey := c.Param("page")
 
-	pages, err := s.renderer.DiscoverPages(s.config.ContentDir)
+	pages, err := s.parser.DiscoverPages(s.config.ContentDir)
 
 	if err != nil {
 		return fmt.Errorf("error discovering pages: %w", err)
@@ -157,7 +157,7 @@ func (s *Server) servePage(c echo.Context) error {
 	var page *content.Page
 
 	if pageKey == "" {
-		page, err = s.renderer.FindRootPage(pages)
+		page, err = s.parser.FindRootPage(pages)
 
 		if err != nil {
 			return serveNotFound(c)
@@ -171,7 +171,7 @@ func (s *Server) servePage(c echo.Context) error {
 		}
 	}
 
-	allPageTitles := s.renderer.AllPageTitles(pages)
+	allPageTitles := s.parser.AllPageTitles(pages)
 
 	return c.Render(http.StatusOK, "page", content.PageTemplateData{
 		AllPageTitles: allPageTitles,
@@ -258,7 +258,7 @@ func NewServer(config Config) *Server {
 		echoInst: echoInst,
 		config:   config,
 		oauth:    oauthConfig,
-		renderer: &content.Renderer{DiscordUserResolver: resolver},
+		parser:   &content.Parser{DiscordUserResolver: resolver},
 	}
 
 	echoInst.HTTPErrorHandler = server.httpError


### PR DESCRIPTION
Resolves #28 

This PR implements a new Goldmark extension to handle Discord mentions of the format `<@ID>`, resolving them to the user's username. It is designed to reduce work done (it fetches each ID only once per program execution, caching resolved values), and to fail gracefully (rendering the raw mention in the event the ID fails to resolve or the credentials for the resolver are not provided.

This has been tested by adding a mention to my page in the example content, which is confirmed to work correctly
![image](https://github.com/user-attachments/assets/c40d9da3-5a73-4e2f-9775-edfce882873d)
