### PR TITLE
Cache discord usernames

### DIFF
--- a/almanac.toml.dist
+++ b/almanac.toml.dist
@@ -9,3 +9,4 @@
 # guild_id =
 # session_secret =
 # token =
+# cache_path =

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -18,7 +18,12 @@ var outputCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		contentDir := must(cmd.Flags().GetString("content-dir"))
 
-		resolver, err := extensions.NewDiscordUserResolver(viper.GetString("discord.token"))
+		resolver, err := extensions.NewDiscordUserResolver(
+			extensions.DiscordUserResolverConfig{
+				DiscordToken: viper.GetString("discord.token"),
+				CachePath:    viper.GetString("discord.cache_path"),
+			},
+		)
 		if err != nil {
 			slog.Warn("Failed to create Discord user resolver, Discord user mentions will not be resolved", "error", err)
 		}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -24,6 +24,7 @@ var serveCmd = &cobra.Command{
 			DiscordGuildId:      viper.GetString("discord.guild_id"),
 			SessionSecret:       viper.GetString("discord.session_secret"),
 			DiscordToken:        viper.GetString("discord.token"),
+			DiscordCachePath:    viper.GetString("discord.cache_path"),
 		})
 		err := serverInstance.Start()
 		checkError(err, "failed to start server")

--- a/pkg/content/extensions/discord_mention.go
+++ b/pkg/content/extensions/discord_mention.go
@@ -158,7 +158,7 @@ func (r *DiscordUserResolver) Resolve(userId string) string {
 	if r.config.CachePath != "" {
 		f, err := os.Create(r.config.CachePath)
 		if err != nil {
-			slog.Error("failed to open cache file", "error", err)
+			slog.Error("Failed to open cache file", "error", err)
 		} else {
 			defer f.Close()
 

--- a/pkg/content/extensions/discord_mention.go
+++ b/pkg/content/extensions/discord_mention.go
@@ -1,8 +1,11 @@
 package extensions
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/yuin/goldmark"
@@ -120,17 +123,23 @@ func (d *DiscordMention) Extend(m goldmark.Markdown) {
 		AddOptions(parser.WithInlineParsers(util.Prioritized(&discordMentionParser{}, 500)))
 }
 
+type CachedMention struct {
+	Username  string
+	CacheTime time.Time
+}
+
 type DiscordUserResolver struct {
-	cache         map[string]string
+	config        DiscordUserResolverConfig
+	cache         map[string]CachedMention
 	discordClient *discordgo.Session
 }
 
 func (r *DiscordUserResolver) Resolve(userId string) string {
-	if cachedVal, ok := r.cache[userId]; ok {
-		return cachedVal
+	if cachedVal, ok := r.cache[userId]; ok && time.Since(cachedVal.CacheTime) < time.Hour*24*7 {
+		return cachedVal.Username
 	}
 
-	slog.Info("Resolving user for the first time, subsequent mentions will be cached...", slog.String("user_id", userId))
+	slog.Info("Resolving user...", slog.String("user_id", userId))
 
 	var username string
 	user, err := r.discordClient.User(userId)
@@ -141,24 +150,66 @@ func (r *DiscordUserResolver) Resolve(userId string) string {
 		username = user.Username
 	}
 
-	r.cache[userId] = username
+	r.cache[userId] = CachedMention{
+		Username:  username,
+		CacheTime: time.Now(),
+	}
+
+	if r.config.CachePath != "" {
+		f, err := os.Create(r.config.CachePath)
+		if err != nil {
+			slog.Error("failed to open cache file", "error", err)
+		} else {
+			defer f.Close()
+
+			err = json.NewEncoder(f).Encode(r.cache)
+			if err != nil {
+				slog.Error("Failed to encode cache file", "error", err)
+			}
+		}
+	}
 
 	return username
 }
 
-func NewDiscordUserResolver(botToken string) (*DiscordUserResolver, error) {
-	if botToken == "" {
+type DiscordUserResolverConfig struct {
+	CachePath    string
+	DiscordToken string
+}
+
+func NewDiscordUserResolver(config DiscordUserResolverConfig) (*DiscordUserResolver, error) {
+	var cache map[string]CachedMention
+	if config.CachePath == "" {
+		slog.Warn("No cache path provided, Discord mention details will not be persisted across Almanac executions")
+		cache = make(map[string]CachedMention)
+	} else if _, err := os.Stat(config.CachePath); os.IsNotExist(err) {
+		cache = make(map[string]CachedMention)
+	} else {
+		f, err := os.Open(config.CachePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open cache file: %w", err)
+		}
+		defer f.Close()
+
+		err = json.NewDecoder(f).Decode(&cache)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode cache file: %w", err)
+		}
+	}
+
+	if config.DiscordToken == "" {
 		return nil, fmt.Errorf("bot token cannot be empty")
 	}
 
-	discordClient, err := discordgo.New("Bot " + botToken)
+	discordClient, err := discordgo.New("Bot " + config.DiscordToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Discord client: %w", err)
 	}
 
 	return &DiscordUserResolver{
-		cache:         make(map[string]string),
+		cache:         cache,
 		discordClient: discordClient,
+		config:        config,
 	}, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,6 +34,7 @@ type Config struct {
 	DiscordGuildId      string
 	SessionSecret       string
 	DiscordToken        string
+	DiscordCachePath    string
 }
 
 type Server struct {
@@ -228,7 +229,12 @@ func NewServer(config Config) *Server {
 		}
 	}
 
-	resolver, err := extensions.NewDiscordUserResolver(config.DiscordToken)
+	resolver, err := extensions.NewDiscordUserResolver(
+		extensions.DiscordUserResolverConfig{
+			DiscordToken: config.DiscordToken,
+			CachePath:    config.DiscordCachePath,
+		},
+	)
 	if err != nil {
 		slog.Warn("Failed to create Discord user resolver, Discord user mentions will not be resolved", "error", err)
 	}


### PR DESCRIPTION
Resolves #31 

Optionally cache discord mentions to a JSON file for a week, to reduce calls to the Discord API when repeatedly re-running Almanac.